### PR TITLE
Copy table styles from google chrome

### DIFF
--- a/dataGrid/dataGrid.css
+++ b/dataGrid/dataGrid.css
@@ -1,0 +1,249 @@
+.data-grid {
+  position: relative;
+  line-height: 120%;
+}
+
+.data-grid table {
+  table-layout: fixed;
+  border-spacing: 0;
+  border-collapse: separate;
+  height: 100%;
+  width: 100%;
+}
+
+.data-grid .header-container,
+.data-grid .data-container {
+  position: absolute;
+  left: 0;
+  right: 0;
+  overflow-x: hidden;
+}
+
+.data-grid .header-container {
+  top: 0;
+  height: 21px;
+}
+
+.data-grid .data-container {
+  top: 21px;
+  bottom: 0;
+  overflow-y: overlay;
+  transform: translateZ(0);
+}
+
+.data-grid.inline .header-container,
+.data-grid.inline .data-container {
+  position: static;
+}
+
+.data-grid.inline .corner {
+  display: none;
+}
+
+.platform-mac .data-grid .corner,
+.data-grid.data-grid-fits-viewport .corner {
+  display: none;
+}
+
+.data-grid .corner {
+  width: 14px;
+  padding-right: 0;
+  padding-left: 0;
+  border-left: 0 none transparent !important;
+}
+
+.data-grid .top-filler-td,
+.data-grid .bottom-filler-td {
+  height: auto !important;
+  padding: 0 !important;
+}
+
+.data-grid table.data {
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  border-top: 0 none transparent;
+  table-layout: fixed;
+}
+
+.data-grid.inline table.data {
+  position: static;
+}
+
+.data-grid table.data tr {
+  display: none;
+  height: 20px;
+}
+
+.data-grid table.data tr.revealed {
+  display: table-row;
+}
+
+.striped-data-grid .revealed.data-grid-data-grid-node:nth-child(odd),
+.striped-data-grid-starts-with-odd .revealed.data-grid-data-grid-node:nth-child(even) {
+  background-color: hsl(214, 70%, 97%);
+}
+
+.data-grid td,
+.data-grid th {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  line-height: 18px;
+  height: 18px;
+  border-left: 1px solid #aaa;
+  padding: 1px 4px;
+}
+
+.data-grid th:first-child,
+.data-grid td:first-child {
+  border-left: none !important;
+}
+
+.data-grid td {
+  vertical-align: top;
+  -webkit-user-select: text;
+}
+
+.data-grid th {
+  text-align: left;
+  background-color: var(--toolbar-bg-color);
+  border-bottom: 1px solid #aaa;
+  font-weight: normal;
+  vertical-align: middle;
+}
+
+.data-grid td > div,
+.data-grid th > div {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+.data-grid td.editing > div {
+  text-overflow: clip;
+}
+
+.data-grid .center {
+  text-align: center;
+}
+
+.data-grid .right {
+  text-align: right;
+}
+
+.data-grid th.sortable {
+  position: relative;
+}
+
+.data-grid th.sortable:active::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.15);
+}
+
+.data-grid th .sort-order-icon-container {
+  position: absolute;
+  top: 1px;
+  right: 0;
+  bottom: 1px;
+  display: flex;
+  align-items: center;
+}
+
+.data-grid th .sort-order-icon {
+  margin-right: 4px;
+  margin-bottom: -2px;
+  display: none;
+}
+
+.data-grid th.sort-ascending .sort-order-icon,
+.data-grid th.sort-descending .sort-order-icon {
+  display: block;
+}
+
+.data-grid th.sortable:hover {
+  background-color: hsla(0, 0%, 90%, 1);
+}
+
+.data-grid button {
+  line-height: 18px;
+  color: inherit;
+}
+
+.data-grid td.disclosure::before {
+  -webkit-user-select: none;
+  -webkit-mask-image: url(Images/treeoutlineTriangles.svg);
+  -webkit-mask-position: 0 0;
+  -webkit-mask-size: 32px 24px;
+  float: left;
+  width: 8px;
+  height: 12px;
+  margin-right: 2px;
+  content: "";
+  position: relative;
+  top: 3px;
+  background-color: rgb(110, 110, 110);
+}
+
+.data-grid tr:not(.parent) td.disclosure::before {
+  background-color: transparent;
+}
+
+
+.data-grid tr.expanded td.disclosure::before {
+  -webkit-mask-position: -16px 0;
+}
+
+.data-grid table.data tr.revealed.selected {
+  background-color: rgb(212, 212, 212);
+  color: inherit;
+}
+
+.data-grid:focus table.data tr.selected {
+  background-color: var(--selection-bg-color);
+  color: var(--selection-fg-color);
+}
+
+.data-grid:focus tr.selected .devtools-link {
+  color: var(--selection-fg-color);
+}
+
+.data-grid:focus tr.parent.selected td.disclosure::before {
+  background-color: var(--selection-fg-color);
+  -webkit-mask-position: 0 0;
+}
+
+.data-grid:focus tr.expanded.selected td.disclosure::before {
+  background-color: var(--selection-fg-color);
+  -webkit-mask-position: -16px 0;
+}
+
+.data-grid tr.inactive {
+  color: rgb(128, 128, 128);
+  font-style: italic;
+}
+
+.data-grid tr.dirty {
+  background-color: hsl(0, 100%, 92%);
+  color: red;
+  font-style: normal;
+}
+
+.data-grid:focus tr.selected.dirty {
+  background-color: hsl(0, 100%, 70%);
+}
+
+.data-grid-resizer {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 5px;
+  z-index: 500;
+}

--- a/panel.css
+++ b/panel.css
@@ -1,5 +1,161 @@
-table {
+@import "dataGrid/dataGrid.css";
+
+:root {
+  height: 100%;
+  overflow: hidden;
+}
+
+:root {
+  --accent-color: #1a73e8;
+  --accent-fg-color: #1a73e8;
+  --accent-color-hover: #3b86e8;
+  --focus-bg-color: hsl(214, 40%, 92%);
+  --toolbar-bg-color: #f3f3f3;
+  --toolbar-hover-bg-color: #eaeaea;
+  --selection-fg-color: white;
+  --selection-inactive-fg-color: #5a5a5a;
+  --selection-inactive-bg-color: #dadada;
+  --tab-selected-fg-color: #333;
+  --tab-selected-bg-color: var(--toolbar-bg-color);
+  --drop-shadow: 0 0 0 1px rgba(0, 0, 0, 0.05),
+                 0 2px 4px rgba(0, 0, 0, 0.2),
+                 0 2px 6px rgba(0, 0, 0, 0.1);
+  --divider-color: #d0d0d0;
+  --focus-ring-inactive-shadow: 0 0 0 1px #e0e0e0;
+  --editor-selection-bg-color: #cfe8fc;
+  --editor-selection-inactive-bg-color: #e0e0e0;
+}
+
+.dark-theme {
+  --accent-color: #0e639c;
+  --accent-fg-color: #cccccc;
+  --accent-color-hover: rgb(17, 119, 187);
+  --focus-bg-color: hsl(214, 19%, 27%);
+  --toolbar-bg-color: #333333;
+  --toolbar-hover-bg-color: #202020;
+  --selection-fg-color: #cdcdcd;
+  --selection-inactive-fg-color: #cdcdcd;
+  --selection-inactive-bg-color: hsl(0, 0%, 28%);
+  --tab-selected-fg-color: #eaeaea;
+  --tab-selected-bg-color: black;
+  --drop-shadow: 0 0 0 1px rgba(255, 255, 255, 0.2),
+                 0 2px 4px 2px rgba(0, 0, 0, 0.2),
+                 0 2px 6px 2px rgba(0, 0, 0, 0.1);
+  --divider-color: #525252;
+  --focus-ring-inactive-shadow: 0 0 0 1px #5a5a5a;
+  --editor-selection-bg-color: hsl(207, 88%, 22%);
+  --editor-selection-inactive-bg-color: #454545;
+}
+
+:root {
+  --focus-ring-active-shadow: 0 0 0 1px var(--accent-color);
+  --selection-bg-color: var(--accent-color);
+  --divider-border: 1px solid var(--divider-color);
+}
+
+* {
+  box-sizing: border-box;
+  min-width: 0;
+  min-height: 0;
+}
+
+html,
+body {
+  height: 100%;
   width: 100%;
+  position: relative;
+  overflow: hidden;
+  margin: 0;
+  cursor: default;
+  font-family: '.SFNSDisplay-Regular', 'Helvetica Neue', 'Lucida Grande', sans-serif;
+  font-size: 12px;
+  tab-size: 4;
+  -webkit-user-select: none;
+}
+
+body {
+  color: rgb(48, 57, 66);
+  font-family: '.SFNSDisplay-Regular', 'Helvetica Neue', 'Lucida Grande', sans-serif;
+}
+
+body.dark-theme {
+  color: rgb(189, 198, 207);
+}
+
+.please-refresh {
+  display: flex;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.dark-theme .please-refresh {
+  color: #fff;
+}
+
+.root-view {
+  background-color: white;
+  overflow: hidden;
+  position: absolute !important;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+}
+
+.dark-theme .root-view {
+  background-color: rgb(36, 36, 36);
+}
+
+.vbox {
+  display: flex;
+  flex-direction: column !important;
+  position: relative;
+}
+
+.widget {
+  position: relative;
+  flex: auto;
+}
+
+.data-grid table {
+  font-size: 12px;
+}
+
+.data-grid tbody tr {
+  height: 20px;
+}
+
+.data-grid th {
+  border-bottom: 1px solid rgb(205, 205, 205);
+  border-left: 1px solid rgb(205, 205, 205);
+}
+
+.dark-theme .data-grid th {
+  border-bottom-color: rgb(61, 61, 61);
+  border-left-color: rgb(61, 61, 61);
+}
+
+.data-grid td {
+  height: 21px;
+  border-left: 1px solid #e1e1e1;
+  vertical-align: middle;
+}
+
+.dark-theme .data-grid td {
+  border-left-color: rgb(51, 51, 51);
+}
+
+.bottom-filler-td {
+  height: auto !important;
+  padding: 0 !important;
+}
+
+/* table {
+  width: 100%;
+}
+
+.dark-theme table {
+  color: #fff;
 }
 
 th {
@@ -8,6 +164,10 @@ th {
   background: white;
 }
 
+.dark-theme th {
+  background: #333;
+}
+
 td {
   text-align: center;
-}
+} */

--- a/panel.html
+++ b/panel.html
@@ -4,6 +4,8 @@
 	<link rel="stylesheet" href="panel.css"></link>
 </head>
 <body>
-<h2>Listening for ad calls. Try refreshing the page!</h2> 
+	<div class="please-refresh">
+		<h2>Listening for ad calls. Try refreshing the page!</h2>
+	</div>
 </body>
 </html>


### PR DESCRIPTION
Super messy but I copied the table styles from chrome devtools network panel. Also added support for dark theme mode. Also added `title` to the table cells so if it's too long you can hover over them to see the rest.

Light theme:
![Screenshot 2019-06-12 11 24 03](https://user-images.githubusercontent.com/14630/59364327-b1918380-8d04-11e9-8dda-e9483b879150.png)

Dark theme:
![Screenshot 2019-06-12 11 24 28](https://user-images.githubusercontent.com/14630/59364328-b1918380-8d04-11e9-8321-081e486c1f41.png)

